### PR TITLE
adding odoh-pauly-version to support newer odoh implementations

### DIFF
--- a/odoh.go
+++ b/odoh.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	ODOH_VERSION                    = uint16(0x0001)
+	ODOH_PAULY_VERSION              = uint16(0xFF06)
 	ODOH_SECRET_LENGTH              = 32
 	ODOH_PADDING_BYTE               = uint8(0)
 	ODOH_LABEL_KEY_ID               = "odoh key id"
@@ -233,7 +234,7 @@ func parseConfigHeader(buffer []byte) (uint16, uint16, error) {
 }
 
 func isSupportedConfigVersion(version uint16) bool {
-	return version == ODOH_VERSION
+	return version == ODOH_VERSION || version == ODOH_PAULY_VERSION
 }
 
 func UnmarshalObliviousDoHConfig(buffer []byte) (ObliviousDoHConfig, error) {
@@ -295,10 +296,12 @@ func UnmarshalObliviousDoHConfigs(buffer []byte) (ObliviousDoHConfigs, error) {
 	for {
 		configVersion, configLength, err := parseConfigHeader(buffer[offset:])
 		if err != nil {
+			fmt.Println("Parse Config Header: %s", err)
 			return ObliviousDoHConfigs{}, errors.New("Invalid ObliviousDoHConfigs encoding")
 		}
 
 		if uint16(len(buffer[offset:])) < configLength {
+			fmt.Println("The configs vector is encoded incorrectly, so discard the whole thing")
 			// The configs vector is encoded incorrectly, so discard the whole thing
 			return ObliviousDoHConfigs{}, errors.New(fmt.Sprintf("Invalid serialized ObliviousDoHConfig, expected %v bytes, got %v", length, len(buffer[offset:])))
 		}
@@ -310,6 +313,7 @@ func UnmarshalObliviousDoHConfigs(buffer []byte) (ObliviousDoHConfigs, error) {
 			}
 		} else {
 			// Skip over unsupported versions
+			fmt.Println("Unsupported Versions!!!")
 		}
 
 		offset += 4 + configLength

--- a/odoh.go
+++ b/odoh.go
@@ -296,12 +296,10 @@ func UnmarshalObliviousDoHConfigs(buffer []byte) (ObliviousDoHConfigs, error) {
 	for {
 		configVersion, configLength, err := parseConfigHeader(buffer[offset:])
 		if err != nil {
-			fmt.Println("Parse Config Header: %s", err)
 			return ObliviousDoHConfigs{}, errors.New("Invalid ObliviousDoHConfigs encoding")
 		}
 
 		if uint16(len(buffer[offset:])) < configLength {
-			fmt.Println("The configs vector is encoded incorrectly, so discard the whole thing")
 			// The configs vector is encoded incorrectly, so discard the whole thing
 			return ObliviousDoHConfigs{}, errors.New(fmt.Sprintf("Invalid serialized ObliviousDoHConfig, expected %v bytes, got %v", length, len(buffer[offset:])))
 		}
@@ -313,7 +311,6 @@ func UnmarshalObliviousDoHConfigs(buffer []byte) (ObliviousDoHConfigs, error) {
 			}
 		} else {
 			// Skip over unsupported versions
-			fmt.Println("Unsupported Versions!!!")
 		}
 
 		offset += 4 + configLength


### PR DESCRIPTION
The Tommy Pauly ODoH Draft (https://datatracker.ietf.org/doc/html/draft-pauly-dprive-oblivious-doh-06) uses version 0xFF06 instead of 0x0001, which is what this package uses.  This PR supplies a simple addition to support both versions from an ODoH endpoint.